### PR TITLE
Fix a bug with stress not being relived

### DIFF
--- a/Client/Emote.lua
+++ b/Client/Emote.lua
@@ -127,7 +127,7 @@ AddEventHandler('animations:client:SmokeWeed', function()
   Citizen.CreateThread(function()
     while SmokingWeed do
       Citizen.Wait(10000)
-      TriggerServerEvent('qb-hud:Server:RelieveStress', math.random(15, 18))
+      TriggerServerEvent('hud:Server:RelieveStress', math.random(15, 18))
       RelieveCount = RelieveCount + 1
       if RelieveCount == 6 then
         if ChosenDict == "MaleScenario" and IsInAnimation then


### PR DESCRIPTION
The event is called `hud:server:RelieveStress` in qb-hud so it should the correct one