### PR TITLE
Introduce callbacks to invoke serverside logic at the right place

### DIFF
--- a/Client/Emote.lua
+++ b/Client/Emote.lua
@@ -122,12 +122,14 @@ AddEventHandler('animations:ToggleCanDoAnims', function(bool)
 end)
 
 RegisterNetEvent('animations:client:SmokeWeed')
-AddEventHandler('animations:client:SmokeWeed', function()
+AddEventHandler('animations:client:SmokeWeed', function(tickCallback)
   SmokingWeed = true
   Citizen.CreateThread(function()
     while SmokingWeed do
       Citizen.Wait(10000)
-      TriggerServerEvent('qb-hud:Server:RelieveStress', math.random(15, 18))
+      if tickCallback ~= nil then
+        tickCallback()
+      end
       RelieveCount = RelieveCount + 1
       if RelieveCount == 6 then
         if ChosenDict == "MaleScenario" and IsInAnimation then


### PR DESCRIPTION
This decouples the server triggers from qbemotes. The actual TriggerServerEvent is passed as a function via qb-smallresources in this PR: https://github.com/qbcore-framework/qb-smallresources/pull/28
