### PR TITLE
Make dpemotes use the QB command system to work with qb-commandbinding

### DIFF
--- a/Client/Emote.lua
+++ b/Client/Emote.lua
@@ -46,71 +46,45 @@ end)
 -- Commands / Events --------------------------------------------------------------------------------
 -----------------------------------------------------------------------------------------------------
 
-Citizen.CreateThread(function()
-    TriggerEvent('chat:addSuggestion', '/e', 'Play an emote', {{ name="emotename", help="dance, camera, sit or any valid emote."}})
-    TriggerEvent('chat:addSuggestion', '/e', 'Play an emote', {{ name="emotename", help="dance, camera, sit or any valid emote."}})
-    TriggerEvent('chat:addSuggestion', '/emote', 'Play an emote', {{ name="emotename", help="dance, camera, sit or any valid emote."}})
-    if Config.SqlKeybinding then
-      TriggerEvent('chat:addSuggestion', '/emotebind', 'Bind an emote', {{ name="key", help="num4, num5, num6, num7. num8, num9. Numpad 4-9!"}, { name="emotename", help="dance, camera, sit or any valid emote."}})
-      TriggerEvent('chat:addSuggestion', '/emotebinds', 'Check your currently bound emotes.')
-    end
-    TriggerEvent('chat:addSuggestion', '/emotemenu', 'Open dpemotes menu (F3) by default.')
-    TriggerEvent('chat:addSuggestion', '/emotes', 'List available emotes.')
-    TriggerEvent('chat:addSuggestion', '/walk', 'Set your walkingstyle.', {{ name="style", help="/walks for a list of valid styles"}})
-    TriggerEvent('chat:addSuggestion', '/walks', 'List available walking styles.')
-end)
-
-RegisterCommand('e', function(source, args, raw)
+RegisterNetEvent('animations:client:PlayEmote', function(args)
     if not PlayerData.metadata['inlaststand'] and not PlayerData.metadata['isdead'] then
-        EmoteCommandStart(source, args, raw)
-    end
-end)
-
-RegisterCommand('emote', function(source, args, raw)
-    if not PlayerData.metadata['inlaststand'] and not PlayerData.metadata['isdead'] then
-        EmoteCommandStart(source, args, raw)
+        EmoteCommandStart(source, args)
     end
 end)
 
 if Config.SqlKeybinding then
-    RegisterCommand('emotebind', function(source, args, raw)
+    RegisterNetEvent('animations:client:BindEmote', function(args)
         if not PlayerData.metadata['inlaststand'] and not PlayerData.metadata['isdead'] then
-            EmoteBindStart(source, args, raw)
+            EmoteBindStart(source, args)
         end
     end)
 
-    RegisterCommand('emotebinds', function(source, args, raw)
+    RegisterNetEvent('animations:client:EmoteBinds', function()
         if not PlayerData.metadata['inlaststand'] and not PlayerData.metadata['isdead'] then
-            EmoteBindsStart(source, args, raw)
+            EmoteBindsStart()
         end
     end)
 end
 
-RegisterCommand('emotemenu', function(source, args, raw)
+RegisterNetEvent('animations:client:EmoteMenu', function()
     if not PlayerData.metadata['inlaststand'] and not PlayerData.metadata['isdead'] then
         OpenEmoteMenu()
     end
 end)
 
-RegisterCommand('em', function(source, args, raw)
-    if not PlayerData.metadata['inlaststand'] and not PlayerData.metadata['isdead'] then
-        OpenEmoteMenu()
-    end
-end)
-
-RegisterCommand('emotes', function(source, args, raw)
+RegisterNetEvent('animations:client:ListEmotes', function()
     if not PlayerData.metadata['inlaststand'] and not PlayerData.metadata['isdead'] then
         EmotesOnCommand()
     end
 end)
 
-RegisterCommand('walk', function(source, args, raw)
+RegisterNetEvent('animations:client:Walk', function(args)
     if not PlayerData.metadata['inlaststand'] and not PlayerData.metadata['isdead'] then
-        WalkCommandStart(source, args, raw)
+        WalkCommandStart(source, args)
     end
 end)
 
-RegisterCommand('walks', function(source, args, raw)
+RegisterNetEvent('animations:client:ListWalks', function()
     if not PlayerData.metadata['inlaststand'] and not PlayerData.metadata['isdead'] then
         WalksOnCommand()
     end

--- a/Client/Syncing.lua
+++ b/Client/Syncing.lua
@@ -8,7 +8,7 @@ local requestedemote = ''
 -- Commands / Events --------------------------------------------------------------------------------
 -----------------------------------------------------------------------------------------------------
 if Config.SharedEmotesEnabled then
-    RegisterCommand('nearby', function(source, args, raw)
+    RegisterNetEvent('animations:client:Nearby', function(args)
         if #args > 0 then
             local emotename = string.lower(args[1])
             target, distance = GetClosestPlayer()
@@ -26,7 +26,7 @@ if Config.SharedEmotesEnabled then
         else
           MearbysOnCommand()
         end
-    end, false)
+    end)
 end
 
 RegisterNetEvent("SyncPlayEmote")

--- a/Server/Server.lua
+++ b/Server/Server.lua
@@ -93,3 +93,49 @@ end
 QBCore.Functions.CreateUseableItem("walkstick", function(source, item)
     TriggerClientEvent("dp:Client:UseWalkingStick", source)
 end)
+
+-----------------------------------------------------------------------------------------------------
+-- Commands -------- --------------------------------------------------------------------------------
+-----------------------------------------------------------------------------------------------------
+
+QBCore.Commands.Add('e', 'Play an emote', {{ name="emotename", help="dance, camera, sit or any valid emote."}}, true, function(source, args)
+    TriggerClientEvent('animations:client:PlayEmote', source, args)
+end)
+
+QBCore.Commands.Add('emote', 'Play an emote', {{ name="emotename", help="dance, camera, sit or any valid emote."}}, true, function(source, args)
+    TriggerClientEvent('animations:client:PlayEmote', source, args)
+end)
+
+if Config.SqlKeybinding then
+    QBCore.Commands.Add('emotebind', 'Bind an emote', {{ name="key", help="num4, num5, num6, num7. num8, num9. Numpad 4-9!"}, { name="emotename", help="dance, camera, sit or any valid emote."}}, true, function(source, args)
+		TriggerClientEvent('animations:client:BindEmote', source, args)
+    end)
+
+    QBCore.Commands.Add('emotebinds', 'Check your currently bound emotes.', {}, false, function(source)
+        TriggerClientEvent('animations:client:EmoteBinds', source)
+    end)
+end
+
+QBCore.Commands.Add('emotemenu', 'Open dpemotes menu (F3) by default.', {}, false, function(source)
+	TriggerClientEvent('animations:client:EmoteMenu', source)
+end)
+
+QBCore.Commands.Add('em', 'Open dpemotes menu (F3) by default.', {}, false, function(source)
+    TriggerClientEvent('animations:client:EmoteMenu', source)
+end)
+
+QBCore.Commands.Add('emotes', 'List available emotes.', {}, false, function(source)
+	TriggerClientEvent('animations:client:ListEmotes', source)
+end)
+
+QBCore.Commands.Add('walk', 'Set your walkingstyle.', {{ name="style", help="/walks for a list of valid styles"}}, true, function(source, args)
+	TriggerClientEvent('animations:client:Walk', source, args)
+end)
+
+QBCore.Commands.Add('walks', 'List available walking styles.', {}, false, function(source)
+    TriggerClientEvent('animations:client:ListWalks', source)
+end)
+
+QBCore.Commands.Add('nearby', 'Share emote with a nearby player.', {{ name="emotename", help="hug, handshake, bro or any valid shared emote."}}, true, function(source, args)
+	TriggerClientEvent('animations:client:Nearby', source, args)
+end)


### PR DESCRIPTION
Changes the commands to use the qb-core commands system, so you can eg. bind ```/em``` using [qbcore-framework/qb-commandbinding](https://github.com/qbcore-framework/qb-commandbinding).