### PR TITLE
[fix] dunk and lapdance keys overrode each other

### DIFF
--- a/Client/AnimationList.lua
+++ b/Client/AnimationList.lua
@@ -46,7 +46,7 @@ DP.Walks = {
   ["Default Female"] = {"move_f@multiplayer"},
   ["Default Male"] = {"move_m@multiplayer"},
   ["Drunk"] = {"move_m@drunk@a"},
-  ["Drunk"] = {"move_m@drunk@slightlydrunk"},
+  ["Drunk1"] = {"move_m@drunk@slightlydrunk"},
   ["Drunk2"] = {"move_m@buzzed"},
   ["Drunk3"] = {"move_m@drunk@verydrunk"},
   ["Femme"] = {"move_f@femme@"},
@@ -1341,7 +1341,7 @@ DP.Emotes = {
    {
        EmoteLoop = true,
    }},
-   ["lapdance3"] = {"mini@strip_club@private_dance@part2", "priv_dance_p2", "Lapdance 3", AnimationOptions =
+   ["lapdance4"] = {"mini@strip_club@private_dance@part2", "priv_dance_p2", "Lapdance 4", AnimationOptions =
    {
        EmoteLoop = true,
    }},


### PR DESCRIPTION
**Describe Pull request**
drunk and lapdance emote variations were getting overridden by following emotes so I changed duplicat drunk to drunk1 and the first instance of lapdance3 to lapdance4 since lapdance3 has been the latter this whole time it wont confuse people if they try to use it.

If your PR is to fix an issue mention that issue here

**Questions (please complete the following information):**
- Have you personally loaded this code into an updated qbcore project and checked all it's functionality? [yes/no] (Be honest) no
- Does your code fit the style guidelines? [yes/no] yes
- Does your PR fit the contribution guidelines? [yes/no] yes
