### PR TITLE
fix check for update error

### DIFF
--- a/Server/Updates.lua
+++ b/Server/Updates.lua
@@ -18,6 +18,11 @@ end)
 function checkVersion(err,responseText, headers)
     curVersion = LoadResourceFile(GetCurrentResourceName(), "version")
 
+    if responseText == nil then
+        print("^1"..resourceName.." check for updates failed ^7")
+        return
+    end
+
     if curVersion ~= responseText and tonumber(curVersion) < tonumber(responseText) then
         updateavail = true
         print("\n^1----------------------------------------------------------------------------------^7")


### PR DESCRIPTION
responseText is nil when the network is not good
will throw the following error
`SCRIPT ERROR: @dpemotes/Server/Updates.lua:23: attempt to compare number with nil`